### PR TITLE
:sparkles: 커피챗 등록 클릭 시 멘토 등록 모달 표시 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lucide-react": "^0.483.0",
         "next": "15.2.3",
         "react": "^19.0.0",
+        "react-datepicker": "^8.2.1",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
         "react-hot-toast": "^2.5.2",
@@ -677,6 +678,59 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.27.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.6.tgz",
+      "integrity": "sha512-9GLOPbW8jTeboR2ar9uMMUDUZjpTLscUvOjNvRw2EgppgoLHLUh/P/OW9evULosnvDjhYf2Gwk/gMOP9KvXD2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.1.2",
+        "@floating-ui/utils": "^0.2.9",
+        "tabbable": "^6.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -3133,6 +3187,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -6283,6 +6347,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-datepicker": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.2.1.tgz",
+      "integrity": "sha512-1pyALWM9mTZ7DG7tfcApwBy2kkld9Kz/EI++LhPnoXJAASbvuq6fdsDfkoB3q1JrxF7vhghVmQ759H/rOwUNNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react": "^0.27.3",
+        "clsx": "^2.1.1",
+        "date-fns": "^4.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
@@ -7136,6 +7215,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.0.15",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "lucide-react": "^0.483.0",
     "next": "15.2.3",
     "react": "^19.0.0",
+    "react-datepicker": "^8.2.1",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
     "react-hot-toast": "^2.5.2",

--- a/src/components/coffee-chat/TimeSlotSelectorProps.tsx
+++ b/src/components/coffee-chat/TimeSlotSelectorProps.tsx
@@ -1,0 +1,192 @@
+import React, { useState } from "react";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import { AlertCircle, Clock, Calendar, X } from "lucide-react";
+
+export type DayOfWeek = "월" | "화" | "수" | "목" | "금" | "토" | "일";
+
+export interface TimeSlot {
+  day: DayOfWeek;
+  times: string[];
+}
+
+interface TimeSlotSelectorProps {
+  timeSlots: TimeSlot[];
+  onChange: (timeSlots: TimeSlot[]) => void;
+}
+
+const TimeSlotSelector: React.FC<TimeSlotSelectorProps> = ({
+  timeSlots,
+  onChange,
+}) => {
+  const [activeDay, setActiveDay] = useState<DayOfWeek>("월");
+  const [selectedDate, setSelectedDate] = useState<Date>(() => {
+    const date = new Date();
+    date.setHours(12, 0, 0, 0);
+    return date;
+  });
+
+  // 현재 활성화된 요일의 시간 슬롯
+  const activeTimeSlot = timeSlots.find((slot) => slot.day === activeDay) || {
+    day: activeDay,
+    times: [],
+  };
+
+  // 시간을 HH:mm 형식의 문자열로 변환
+  const formatTimeToString = (date: Date): string => {
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    return `${hours}:${minutes}`;
+  };
+
+  // 문자열을 Date 객체로 변환 (비교용)
+  const parseTimeString = (timeStr: string): Date => {
+    const [hours, minutes] = timeStr.split(":").map(Number);
+    const date = new Date();
+    date.setHours(hours, minutes, 0, 0);
+    return date;
+  };
+
+  // 요일 탭 선택 핸들러
+  const handleDayTabClick = (day: DayOfWeek) => {
+    setActiveDay(day);
+  };
+
+  // DatePicker 값 변경 핸들러
+  const handleTimeChange = (date: Date | null) => {
+    if (!date) return;
+
+    // 선택한 시간을 문자열로 변환
+    const timeString = formatTimeToString(date);
+
+    // 선택한 시간 저장
+    setSelectedDate(date);
+
+    // 시간 추가
+    const updatedTimeSlots = timeSlots.map((slot) => {
+      if (slot.day === activeDay) {
+        const sortedTimes = [...slot.times, timeString].sort();
+        return { ...slot, times: sortedTimes };
+      }
+      return slot;
+    });
+
+    onChange(updatedTimeSlots);
+  };
+
+  // 시간 삭제 핸들러
+  const handleRemoveTime = (day: DayOfWeek, time: string) => {
+    const updatedTimeSlots = timeSlots.map((slot) => {
+      if (slot.day === day) {
+        return { ...slot, times: slot.times.filter((t) => t !== time) };
+      }
+      return slot;
+    });
+
+    onChange(updatedTimeSlots);
+  };
+
+  // 해당 요일의 선택된 시간 수 가져오기
+  const getSelectedTimesCount = (day: DayOfWeek) => {
+    const daySlot = timeSlots.find((slot) => slot.day === day);
+    return daySlot ? daySlot.times.length : 0;
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm overflow-hidden">
+      {/* 요일 탭 */}
+      <div className="flex overflow-x-auto p-1 bg-amber-50 border-b scrollbar-thin scrollbar-thumb-gray-300">
+        {timeSlots.map((slot) => (
+          <button
+            key={slot.day}
+            type="button"
+            className={`flex items-center justify-center px-4 py-2 m-1 rounded-full transition-all ${
+              activeDay === slot.day
+                ? `bg-amber-900 text-white font-medium shadow-sm`
+                : "bg-white shadow-inner text-amber-900 hover:bg-amber-900 hover:text-white"
+            }`}
+            onClick={() => handleDayTabClick(slot.day as DayOfWeek)}
+          >
+            <span className="mr-1">{slot.day}</span>
+            {getSelectedTimesCount(slot.day as DayOfWeek) > 0 && (
+              <span className="bg-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium text-amber-900">
+                {getSelectedTimesCount(slot.day as DayOfWeek)}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <div className="p-4">
+        {/* DatePicker (시간 선택기) */}
+        <div className="mb-4">
+          <div className="flex items-center mb-3">
+            <Clock size={18} className="text-black mr-2" />
+            <span className="font-medium text-gray-700">시간 선택</span>
+          </div>
+          <div className="relative rounded-md">
+            <DatePicker
+              selected={selectedDate}
+              onChange={handleTimeChange}
+              showTimeSelect
+              showTimeSelectOnly
+              timeIntervals={30}
+              timeCaption="시간"
+              dateFormat="HH:mm"
+              timeFormat="HH:mm"
+              className="input"
+              excludeTimes={activeTimeSlot.times.map(parseTimeString)}
+              placeholderText="시간 선택"
+              popperClassName="react-datepicker-right"
+              popperPlacement="right-start"
+              shouldCloseOnSelect={false}
+            />
+          </div>
+          <p className="text-xs text-gray-500 mt-2 flex items-center">
+            <AlertCircle size={12} className="mr-1" />
+            목록에서 시간을 선택하면 자동으로 추가됩니다
+          </p>
+        </div>
+
+        {/* 선택된 시간 표시 */}
+        <div>
+          <div className="flex items-center mb-3">
+            <Calendar size={18} className="text-black mr-2" />
+            <span className="font-medium text-gray-700">
+              {activeDay}요일 선택된 시간
+            </span>
+          </div>
+          <div className="bg-amber-50 rounded-md p-3 min-h-[100px]">
+            {activeTimeSlot.times.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {activeTimeSlot.times.map((time) => (
+                  <div
+                    key={time}
+                    className="w-28 px-3 py-2 rounded-md flex items-center text-sm bg-white text-amber-900 border border-amber-900"
+                  >
+                    <Clock size={14} className="mr-1.5" />
+                    <span>{time}</span>
+                    <button
+                      type="button"
+                      className="ml-2 p-1 rounded-full hover:bg-amber-100 transition-colors"
+                      onClick={() => handleRemoveTime(activeDay, time)}
+                    >
+                      <X size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex items-center justify-center h-16 text-gray-500 text-sm">
+                <AlertCircle size={16} className="mr-2" />
+                아직 선택된 시간이 없습니다
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TimeSlotSelector;

--- a/src/components/coffee-chat/CoffeeChatHeader.tsx
+++ b/src/components/coffee-chat/CoffeeChatHeader.tsx
@@ -1,13 +1,33 @@
-import React from "react";
+"use client";
 
-const CoffeeChatHeader = () => {
+import React, { useState } from "react";
+import MentorSignupModal from "./MentorSignupModal";
+
+const CoffeeChatHeader: React.FC = () => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+
+  const openModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+  };
   return (
-    <div className="flex justify-between items-center mb-6">
-      <h1 className="text-2xl font-bold text-amber-950">커피챗</h1>
-      <button className="px-4 py-2 bg-amber-950 text-white rounded-lg hover:bg-amber-900 transition-colors">
-        커피챗 등록
-      </button>
-    </div>
+    <>
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold text-amber-950">커피챗</h1>
+        <button
+          className="px-4 py-2 bg-amber-950 text-white rounded-lg hover:bg-amber-900 transition-colors"
+          onClick={openModal}
+        >
+          커피챗 등록
+        </button>
+      </div>
+
+      {/* 커피챗 멘토 등록 모달 */}
+      <MentorSignupModal isOpen={isModalOpen} onClose={closeModal} />
+    </>
   );
 };
 

--- a/src/components/coffee-chat/MentorSignupModal.tsx
+++ b/src/components/coffee-chat/MentorSignupModal.tsx
@@ -1,0 +1,236 @@
+import React, { useState } from "react";
+import Modal from "../common/modal/CommonModal";
+import { Clock, PencilLine, UserSearch } from "lucide-react";
+import { toast } from "react-toastify";
+import useMentorRegistration from "@/hooks/coffee-chat/useMentorRegistration";
+import TimeSlotSelector, { TimeSlot } from "./\bTimeSlotSelectorProps";
+
+interface MentorSignupModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export interface MentorSignupFormData {
+  jobType: string;
+  userType: string;
+  introduction: string;
+  timeSlots: TimeSlot[];
+}
+
+const jobCategories = [
+  "프론트엔드",
+  "백엔드",
+  "PM",
+  "UI/UX 디자인",
+  "데이터분석",
+  "기타",
+];
+
+const dayMapping: Record<string, string> = {
+  월: "MONDAY",
+  화: "TUESDAY",
+  수: "WEDNESDAY",
+  목: "THURSDAY",
+  금: "FRIDAY",
+  토: "SATURDAY",
+  일: "SUNDAY",
+};
+
+const MentorSignupModal: React.FC<MentorSignupModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { mentorInfoMutation, timeSlotsMutation, isPending } =
+    useMentorRegistration();
+
+  const [formData, setFormData] = useState<MentorSignupFormData>({
+    jobType: "",
+    userType: "",
+    introduction: "",
+    timeSlots: [
+      { day: "월", times: [] },
+      { day: "화", times: [] },
+      { day: "수", times: [] },
+      { day: "목", times: [] },
+      { day: "금", times: [] },
+      { day: "토", times: [] },
+      { day: "일", times: [] },
+    ],
+  });
+
+  // 직군 선택 핸들러
+  const handleJobCategoryChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormData({
+      ...formData,
+      jobType: e.target.value,
+    });
+  };
+
+  // 현업자 체크박스 핸들러
+  const handleProfessionalChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({
+      ...formData,
+      userType: e.target.checked ? "PROFESSIONAL" : "GENERAL",
+    });
+  };
+
+  // 소개글 핸들러
+  const handleIntroductionChange = (
+    e: React.ChangeEvent<HTMLTextAreaElement>
+  ) => {
+    setFormData({
+      ...formData,
+      introduction: e.target.value,
+    });
+  };
+
+  // 시간 슬롯 변경 핸들러
+  const handleTimeSlotChange = (updatedTimeSlots: TimeSlot[]) => {
+    setFormData({
+      ...formData,
+      timeSlots: updatedTimeSlots,
+    });
+  };
+
+  // 등록 폼 제출 핸들러
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    try {
+      // 시간 선택 확인
+      const hasSelectedTimes = formData.timeSlots.some(
+        (slot) => slot.times.length > 0
+      );
+      if (!hasSelectedTimes) {
+        toast.error("최소 한 개 이상의 가능한 시간을 선택해주세요.");
+        return;
+      }
+
+      // 소개글 길이 확인
+      if (formData.introduction.trim().length < 10) {
+        toast.error("소개글은 최소 10자 이상 작성해주세요.");
+        return;
+      }
+
+      // 필터링된 시간 슬롯 (빈 배열 제거)
+      const filteredTimeSlots = formData.timeSlots.filter(
+        (slot) => slot.times.length > 0
+      );
+
+      const availableTimes: Record<string, string[]> = {};
+
+      console.log("Filtered Time Slots:", filteredTimeSlots);
+
+      filteredTimeSlots.forEach((slot) => {
+        if (slot.times.length > 0) {
+          // 한글 요일을 영어로 변환
+          const day = dayMapping[slot.day];
+          availableTimes[day] = slot.times;
+        }
+      });
+
+      const mentorInfoData = {
+        jobType: formData.jobType,
+        userType: formData.userType || "GENERAL",
+        introduction: formData.introduction,
+      };
+
+      // 멘토 정보 등록 API 호출
+      await mentorInfoMutation.mutateAsync(mentorInfoData);
+
+      await timeSlotsMutation.mutateAsync(availableTimes);
+
+      toast.success("커피챗 멘토로 성공적으로 등록되었습니다!");
+      onClose();
+    } catch (error) {
+      toast.error("멘토 등록 중 오류가 발생했습니다.");
+      console.error("Registration error:", error);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="멘토 등록" size="lg">
+      <form className="space-y-4 " onSubmit={handleSubmit}>
+        {/* 직군 선택 */}
+        <div className="form-control">
+          <label className="label text-black">
+            <UserSearch size={18} className="text-black" />
+            <span className="font-medium">직군 선택</span>
+          </label>
+          <select
+            className="select select-bordered w-full"
+            value={formData.jobType}
+            onChange={handleJobCategoryChange}
+            required
+          >
+            <option value="" disabled>
+              직군을 선택해주세요
+            </option>
+            {jobCategories.map((category) => (
+              <option key={category} value={category}>
+                {category}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* 현업자 체크박스 */}
+        <div className="form-control">
+          <label className="cursor-pointer justify-start label">
+            <input
+              type="checkbox"
+              className="checkbox checkbox-xs checkbox-neutral"
+              checked={formData.userType === "PROFESSIONAL"}
+              onChange={handleProfessionalChange}
+            />
+            <span className="font-medium text-black">
+              현업 종사자인 경우에만 체크해주세요.
+            </span>
+          </label>
+        </div>
+
+        {/* 소개글 */}
+        <div className="form-control flex flex-col">
+          <label className="label text-black">
+            <PencilLine size={18} className="text-black" />
+            <span className="font-medium">멘토 소개글</span>
+          </label>
+          <textarea
+            className="textarea textarea-bordered h-24 mt-1"
+            placeholder="멘티에게 보여질 자기소개와 도움을 줄 수 있는 영역에 대해 작성해주세요. (최소 10자 이상)"
+            value={formData.introduction}
+            onChange={handleIntroductionChange}
+            required
+          />
+        </div>
+
+        {/* 요일별 시간 선택 */}
+        <div className="space-y-2">
+          <div className="label">
+            <Clock size={18} className="text-black" />
+            <span className="font-medium text-black">멘토링 가능 시간</span>
+          </div>
+
+          {/* TimeSlotSelector 컴포넌트 사용 */}
+          <TimeSlotSelector
+            timeSlots={formData.timeSlots}
+            onChange={handleTimeSlotChange}
+          />
+        </div>
+
+        {/* 등록 버튼 */}
+        <div className="pt-2 flex justify-end">
+          <button
+            type="submit"
+            className="btn bg-amber-950 w-full hover:bg-amber-900 text-white"
+            disabled={isPending}
+          >
+            {isPending ? "등록 중..." : "커피챗 멘토로 등록하기"}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default MentorSignupModal;

--- a/src/components/coffee-chat/my-chat/ConfirmedListTab.tsx
+++ b/src/components/coffee-chat/my-chat/ConfirmedListTab.tsx
@@ -4,21 +4,21 @@ const ConfirmedListTab = () => {
   const coffeeChats = [
     {
       id: 1,
-      title: "프론트엔드 개발 이야기",
-      host: "김개발",
+      title: "프론트엔드 상담 받고 싶어요",
+      host: "나",
       date: "2025-03-30",
       status: "예정됨",
     },
     {
       id: 2,
-      title: "리액트 학습 팁",
-      host: "이리액트",
+      title: "리액트 학습 팁 알려주세요",
+      host: "나",
       date: "2025-04-02",
       status: "예정됨",
     },
     {
       id: 3,
-      title: "주니어 개발자 성장기",
+      title: "주니어 개발자 성장에 대해서 궁금해요",
       host: "박주니어",
       date: "2025-04-05",
       status: "예정됨",

--- a/src/components/coffee-chat/my-chat/MyChatTabNavigation.tsx
+++ b/src/components/coffee-chat/my-chat/MyChatTabNavigation.tsx
@@ -7,7 +7,7 @@ const MyChatTabNavigation = () => {
   const { subTab, setSubTab } = useCoffeeChatStore();
 
   const tabs = [
-    { id: SubTab.LIST, label: "커피챗 리스트" },
+    { id: SubTab.LIST, label: "예정 커피챗" },
     { id: SubTab.SENT, label: "보낸 신청" },
     { id: SubTab.RECEIVED, label: "받은 신청" },
     { id: SubTab.CONVERSATIONS, label: "대화목록" },

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -9,4 +9,6 @@ export const END_POINT = {
   FILE_UPLOAD: "/api/file/upload",
   SENT_COFFEE_CHATS: "/api/coffee-chats/applications",
   RECEIVED_COFFEE_CHATS: "/api/coffee-chats/received",
+  MENTOR_INFO: "/api/coffee-chats/info/user-info",
+  MENTOR_TIME: "/api/coffee-chats/times/available-times",
 } as const;

--- a/src/hooks/coffee-chat/useMentorRegistration.ts
+++ b/src/hooks/coffee-chat/useMentorRegistration.ts
@@ -1,0 +1,60 @@
+import { axiosDefault } from "@/api/axiosInstance";
+import { END_POINT } from "@/constants/endPoint";
+import { MentorInfoData } from "@/types/request";
+import { useMutation } from "@tanstack/react-query";
+
+const mentorApi = {
+  // 멘토 기본 정보 등록 API
+  registerMentorInfo: async (mentorInfo: MentorInfoData) => {
+    try {
+      const response = await axiosDefault.post(
+        END_POINT.MENTOR_INFO,
+        mentorInfo
+      );
+      return response.data;
+    } catch (error) {
+      console.error("멘토 정보 등록 오류:", error);
+      throw error;
+    }
+  },
+
+  registerTimeSlots: async (availableTimes: Record<string, string[]>) => {
+    try {
+      const response = await axiosDefault.post(END_POINT.MENTOR_TIME, {
+        availableTimes,
+      });
+      return response.data;
+    } catch (error) {
+      console.error("시간 슬롯 등록 오류:", error);
+      throw error;
+    }
+  },
+};
+
+export const useMentorRegistration = () => {
+  // 멘토 기본 정보 등록 뮤테이션
+  const mentorInfoMutation = useMutation({
+    mutationFn: mentorApi.registerMentorInfo,
+    onError: (error) => {
+      console.error("멘토 정보 등록 오류:", error);
+    },
+  });
+
+  // 시간 슬롯 등록 뮤테이션
+  const timeSlotsMutation = useMutation({
+    mutationFn: mentorApi.registerTimeSlots,
+    onError: (error) => {
+      console.error("시간 슬롯 등록 오류:", error);
+    },
+  });
+
+  return {
+    mentorInfoMutation,
+    timeSlotsMutation,
+    isPending: mentorInfoMutation.isPending || timeSlotsMutation.isPending,
+    isError: mentorInfoMutation.isError || timeSlotsMutation.isError,
+    error: mentorInfoMutation.error || timeSlotsMutation.error,
+  };
+};
+
+export default useMentorRegistration;

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { MentorInfoData, MentorTimeData } from "./../types/request";
 import { END_POINT } from "@/constants/endPoint";
 import { http, HttpResponse } from "msw";
 import { DB } from "./db/db";
@@ -113,5 +114,53 @@ export const handlers = [
 
   http.get(END_POINT.RECEIVED_COFFEE_CHATS, () => {
     return HttpResponse.json(DB.receivedCoffeeChats, {});
+  }),
+
+  http.post(END_POINT.MENTOR_INFO, async ({ request }) => {
+    const body = await request.json();
+    const { userType, jobType, introduction } = body as MentorInfoData;
+
+    if (!userType || !jobType || !introduction) {
+      return HttpResponse.json(
+        {
+          message: "필수 입력 항목이 누락되었습니다.",
+        },
+        { status: 400 }
+      );
+    }
+
+    // 성공 응답
+    return HttpResponse.json(
+      {
+        userType,
+        jobType,
+        introduction,
+      },
+      { status: 200 }
+    );
+  }),
+
+  http.post(END_POINT.MENTOR_TIME, async ({ request }) => {
+    const body = await request.json();
+    const { availableTimes } = body as MentorTimeData;
+
+    if (
+      !availableTimes ||
+      typeof availableTimes !== "object" ||
+      Object.keys(availableTimes).length === 0
+    ) {
+      return HttpResponse.json(
+        {
+          message: "가능한 시간대를 하나 이상 입력해주세요.",
+        },
+        { status: 400 }
+      );
+    }
+    return HttpResponse.json(
+      {
+        availableTimes,
+      },
+      { status: 200 }
+    );
   }),
 ];

--- a/src/types/request.ts
+++ b/src/types/request.ts
@@ -3,3 +3,22 @@ export interface ProfileFormData {
   profile_image?: string | null;
   desired_career: string;
 }
+
+export interface MentorInfoData {
+  userType: string;
+  jobType: string;
+  introduction: string;
+}
+
+export interface MentorTimeData {
+  availableTimes: Record<
+    | "MONDAY"
+    | "TUESDAY"
+    | "WEDNESDAY"
+    | "THURSDAY"
+    | "FRIDAY"
+    | "SATURDAY"
+    | "SUNDAY",
+    string[]
+  >;
+}


### PR DESCRIPTION
## 변경사항 설명
<!-- 어떤 변경사항이 있었는지 간략히 설명해주세요 -->
- 커피챗 등록 버튼 클릭 시 멘토 등록 모달 창이 열리도록 기능 추가
- 모달 내 직군 선택, 시간 선택, 소개글 입력 등의 폼 구성 완료

## 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 작성해주세요 (예: #123) -->
#14

## 리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이 있다면 알려주세요 -->
- 모달 상태 관리 및 폼 데이터 흐름이 적절히 구성되어 있는지
- TimeSlotSelector와 MentorSignupModal 간 데이터 주고받는 로직의 안정성

## 테스트 방법
<!-- 이 변경사항을 테스트하는 방법을 설명해주세요 -->
1. 메인 화면에서 "커피챗 등록" 버튼 클릭
2. 모달 창이 정상적으로 열리는지 확인
3. 각 필드를 입력 후 "등록" 버튼 클릭 시 로딩 및 API 연동 흐름 확인
4. 최소 요건 미충족 시 토스트 메시지 출력되는지 확인

## 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
![스크린샷 2025-04-05 오전 3 24 50](https://github.com/user-attachments/assets/53c00286-2588-40c8-a21b-d3b74337bcd5)
![스크린샷 2025-04-05 오전 3 25 41](https://github.com/user-attachments/assets/b3c36152-cbdf-410b-b8ac-ece8c053ae0b)

## 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 모든 테스트가 통과합니다
- [x] 관련 문서를 업데이트했습니다
