### PR TITLE
:recycle: 종료된 채팅 REST API 불러오기 및 시간 포맷팅 통일

### DIFF
--- a/src/app/(protected)/chat/page.tsx
+++ b/src/app/(protected)/chat/page.tsx
@@ -4,6 +4,9 @@ import { useState } from "react";
 import { useGetChatList } from "@/hooks/chat/useGetChatList";
 import { ChatRoom } from "@/types/response";
 import ChatRoomPage from "./[roomId]/page";
+import Image from "next/image";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale/ko";
 
 // 상수 정의
 const CHAT_STATUS = {
@@ -12,14 +15,10 @@ const CHAT_STATUS = {
   UPCOMING: "예정",
 };
 
-const formatDate = (dateStr: string) =>
-  new Date(dateStr).toLocaleString("ko-KR", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+const formatDate = (dateStr: string) => {
+  const date = new Date(dateStr);
+  return format(date, "yyyy-MM-dd HH:mm", { locale: ko });
+};
 
 const getStatusText = (chatRoom: ChatRoom) => {
   const now = new Date();
@@ -32,7 +31,7 @@ const getStatusText = (chatRoom: ChatRoom) => {
   return "현재 진행 중입니다.";
 };
 
-const userId = 8050; // 유저id
+const userId = 9080; // 유저id
 
 const ChatPage = () => {
   const { chatRoomList = [] } = useGetChatList();
@@ -59,7 +58,7 @@ const ChatPage = () => {
                 {chatRoomList.map((chatRoom) => (
                   <div
                     key={chatRoom.roomUuid}
-                    className={`relative p-3 rounded-lg shadow-sm border border-gray-300 hover:shadow-md  transition-all cursor-pointer ${
+                    className={`p-3 rounded-lg shadow-sm border border-gray-300 hover:shadow-md  transition-all cursor-pointer ${
                       chatRoom.isActive
                         ? "bg-white"
                         : "bg-gray-50 text-gray-400"
@@ -67,26 +66,55 @@ const ChatPage = () => {
                     )}`}
                     onClick={() => handleChatSelect(chatRoom.roomUuid)}
                   >
-                    <div className="flex justify-between items-center mb-2">
-                      <h4 className="font-medium text-sm">
-                        {chatRoom.mentor.userId === userId
-                          ? chatRoom.mentee.name
-                          : chatRoom.mentor.name}
-                      </h4>
-                      <span
-                        className={`text-xs ${
-                          chatRoom.isActive ? "text-blue-500" : "text-gray-500"
-                        }`}
-                      >
-                        {chatRoom.isActive
-                          ? CHAT_STATUS.ONGOING
-                          : chatRoom.endAt
-                          ? CHAT_STATUS.ENDED
-                          : CHAT_STATUS.UPCOMING}
-                      </span>
-                    </div>
-                    <div className="text-xs text-gray-500 mb-1">
-                      {getStatusText(chatRoom)}
+                    <div className="flex items-between">
+                      {/* 프로필 이미지 */}
+                      <div className="w-10 h-10 mr-3 rounded-full overflow-hidden flex-shrink-0">
+                        <Image
+                          src={
+                            chatRoom.mentee.userId === userId
+                              ? chatRoom.mentor.profileImage ||
+                                "/profile-default.png"
+                              : chatRoom.mentee.profileImage ||
+                                "/profile-default.png"
+                          }
+                          alt="프로필 이미지"
+                          width={40}
+                          height={40}
+                          className="object-cover w-full h-full"
+                          onClick={(e) => e.stopPropagation()}
+                          onError={(e) => {
+                            const target = e.target as HTMLImageElement;
+                            target.src = "/profile-default.png";
+                          }}
+                        />
+                      </div>
+
+                      {/* 텍스트 컨텐츠 */}
+                      <div className="flex-1 min-w-0 w-full">
+                        <div className="flex justify-between items-center w-full">
+                          <h4 className="font-medium text-sm truncate">
+                            {chatRoom.mentor.userId === userId
+                              ? chatRoom.mentee.name
+                              : chatRoom.mentor.name}
+                          </h4>
+                          <span
+                            className={`text-xs flex-shrink-0 ml-auto ${
+                              chatRoom.isActive
+                                ? "text-blue-500"
+                                : "text-gray-500"
+                            }`}
+                          >
+                            {chatRoom.isActive
+                              ? CHAT_STATUS.ONGOING
+                              : chatRoom.endAt
+                              ? CHAT_STATUS.ENDED
+                              : CHAT_STATUS.UPCOMING}
+                          </span>
+                        </div>
+                        <div className="text-xs text-gray-500 mt-1 truncate">
+                          {getStatusText(chatRoom)}
+                        </div>
+                      </div>
                     </div>
                   </div>
                 ))}

--- a/src/components/feature/coffee-chat/my-chat/ApprovedListTab.tsx
+++ b/src/components/feature/coffee-chat/my-chat/ApprovedListTab.tsx
@@ -6,6 +6,8 @@ import { CoffeeChat } from "@/types/response";
 import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import CoffeeChatDetailModal from "./CoffeeChatDetailModal";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale/ko";
 
 const ApprovedListTab = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -34,14 +36,8 @@ const ApprovedListTab = () => {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString("ko-KR", {
-      year: "numeric",
-      month: "numeric",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
+    const date = new Date(dateString);
+    return format(date, "yyyy-MM-dd HH:mm", { locale: ko });
   };
 
   if (isLoading) {

--- a/src/components/feature/coffee-chat/my-chat/CoffeeChatDetailModal.tsx
+++ b/src/components/feature/coffee-chat/my-chat/CoffeeChatDetailModal.tsx
@@ -10,6 +10,8 @@ import {
 import { CoffeeChat } from "@/types/response";
 import Modal from "@/components/common/modal/CommonModal";
 import { getStatusBadge } from "./getStatusBadge";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale/ko";
 
 interface CoffeeChatDetailModalProps {
   isOpen: boolean;
@@ -29,6 +31,16 @@ const CoffeeChatDetailModal: React.FC<CoffeeChatDetailModalProps> = ({
   isSent = false, // 기본값: false
 }) => {
   if (!coffeeChat) return null;
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return format(date, "yyyy-MM-dd", { locale: ko });
+  };
+
+  const formatTime = (dateString: string) => {
+    const date = new Date(dateString);
+    return format(date, "HH:mm", { locale: ko });
+  };
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="md" title="커피챗 상세 정보">
@@ -53,26 +65,13 @@ const CoffeeChatDetailModal: React.FC<CoffeeChatDetailModalProps> = ({
         <div className="flex items-center">
           <Calendar size={18} className="mr-2 " />
           <span className="mr-2 font-medium">신청 일시:</span>
-          <span>
-            {new Date(coffeeChat.coffeeChatStartTime).toLocaleDateString(
-              "ko-KR"
-            )}
-          </span>
+          <span>{formatDate(coffeeChat.coffeeChatStartTime)}</span>
         </div>
 
         <div className="flex items-center">
           <Clock size={18} className="mr-2 " />
           <span className="mr-2 font-medium">신청 시간:</span>
-          <span>
-            {new Date(coffeeChat.coffeeChatStartTime).toLocaleTimeString(
-              "ko-KR",
-              {
-                hour: "2-digit",
-                minute: "2-digit",
-                hour12: false,
-              }
-            )}
-          </span>
+          <span>{formatTime(coffeeChat.coffeeChatStartTime)}</span>
         </div>
 
         {/* 메시지 */}

--- a/src/components/feature/coffee-chat/my-chat/ReceivedListTab.tsx
+++ b/src/components/feature/coffee-chat/my-chat/ReceivedListTab.tsx
@@ -9,6 +9,8 @@ import CoffeeChatDetailModal from "./CoffeeChatDetailModal";
 import { getStatusBadge } from "./getStatusBadge";
 import { useCoffeeChatActions } from "@/hooks/coffee-chat/useCoffeeChatActions";
 import CoffeeChatActionModal from "./CoffeeChatActionModal";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale/ko";
 
 const ReceivedListTab = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -50,14 +52,8 @@ const ReceivedListTab = () => {
 
   // 날짜 포맷 헬퍼 함수
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString("ko-KR", {
-      year: "numeric",
-      month: "numeric",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
+    const date = new Date(dateString);
+    return format(date, "yyyy-MM-dd HH:mm", { locale: ko });
   };
 
   const isNow = new Date();

--- a/src/components/feature/coffee-chat/my-chat/SentListTab.tsx
+++ b/src/components/feature/coffee-chat/my-chat/SentListTab.tsx
@@ -9,6 +9,8 @@ import CoffeeChatDetailModal from "./CoffeeChatDetailModal";
 import { getStatusBadge } from "./getStatusBadge";
 import { useCoffeeChatActions } from "@/hooks/coffee-chat/useCoffeeChatActions";
 import CoffeeChatActionModal from "./CoffeeChatActionModal";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale/ko";
 
 const SentListTab = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -41,14 +43,8 @@ const SentListTab = () => {
 
   // 날짜 포맷 헬퍼 함수
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleString("ko-KR", {
-      year: "numeric",
-      month: "numeric",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
+    const date = new Date(dateString);
+    return format(date, "yyyy-MM-dd HH:mm", { locale: ko });
   };
 
   if (isLoading) {

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -8,7 +8,7 @@ export const END_POINT = {
   MY_REVIEWS: "/api/reviews/my",
   POINT_HISTORY: "api/points/my",
   COURSES: "api/courses/autocomplete",
-  CERTIFICATE: "/api/users/certification",
+  CERTIFICATE: "/api/users/my/certification",
   MENTOR_LIST: "/api/coffee-chats/info/search",
   APPROVED_COFFEE_CHATS: "/api/coffee-chats/applications/approved",
   FILE_UPLOAD: "/api/file/upload",
@@ -30,5 +30,5 @@ export const END_POINT = {
   LOGOUT: "/api/logout",
   UPDATE_REVIEW: (reviewId: number) => `/api/reviews/my/${reviewId}`,
   DELETE_REVIEW: (reviewId: number) => `/api/reviews/my/${reviewId}`,
-  SSE_CONNECT: "/api/sse-connect"
+  SSE_CONNECT: "/api/sse-connect",
 } as const;

--- a/src/hooks/chat/useGetMessages.ts
+++ b/src/hooks/chat/useGetMessages.ts
@@ -9,10 +9,11 @@ const fetchPreviousMessages = async (roomUuid: string) => {
   return response.data;
 };
 
-export const useGetMessages = () => {
-  const { data: previousMessages } = useQuery({
-    queryKey: ["previousMessages"],
-    queryFn: () => fetchPreviousMessages,
+export const useGetMessages = (roomUuid: string) => {
+  const { data: previousMessages, isLoading } = useQuery({
+    queryKey: ["previousMessages", roomUuid],
+    queryFn: () => fetchPreviousMessages(roomUuid),
+    enabled: !!roomUuid,
   });
-  return { previousMessages };
+  return { previousMessages, isLoading };
 };


### PR DESCRIPTION
## 변경사항 설명
<!-- 어떤 변경사항이 있었는지 간략히 설명해주세요 -->
- 종료된 채팅방 데이터 REST API로 불러오는 기능 추가
- 시간 포맷팅을 24시간 형식(HH:MM)으로 통일
- 채팅방 목록 UI 개선 및 프로필 이미지 표시 추가
- 시스템 메시지 중앙 정렬 표시 기능 구현
## 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 작성해주세요 (예: #123) -->
#33 
## 리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이 있다면 알려주세요 -->
- 종료된 채팅방 데이터 불러오기 로직이 적절한지 확인
- 시스템 메시지 표시 방식 검토
- 채팅/커피챗 페이지 시간 표시 방식 통일 여부 확인
## 테스트 방법
<!-- 이 변경사항을 테스트하는 방법을 설명해주세요 -->
1. 활성 채팅방과 종료된 채팅방 모두 접속해서 메시지 목록 확인
2. 시스템 메시지(입장 메시지)가 화면 중앙에 올바르게 표시되는지 확인
3. 채팅방 목록에서 프로필 이미지가 정상적으로 표시되는지 확인
4. 모든 시간 표시 부분이 24시간 형식(HH:MM)으로 통일되었는지 확인
## 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
<img width="305" alt="스크린샷 2025-04-19 오후 11 40 23" src="https://github.com/user-attachments/assets/d142672b-af45-47d5-bbad-8db6323d30f4" />
<img width="461" alt="스크린샷 2025-04-19 오후 11 46 08" src="https://github.com/user-attachments/assets/81053d4b-e517-4192-9a8f-35ce2a6984ec" />

## 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 모든 테스트가 통과합니다

