### PR TITLE
✨ 소셜 로그인 수정 및 헤더 포인트 표시 수정

### DIFF
--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { useEffect } from "react";
 
@@ -9,15 +9,12 @@ export default function Page() {
 
     if (token) {
       localStorage.setItem("access_token", token);
-      console.log("token 저장 완료:", token);
 
       // URL 정리 (token 제거)
       const cleanUrl = window.location.origin + window.location.pathname;
       window.history.replaceState({}, document.title, cleanUrl);
-    } else {
-      console.warn("URL에서 token을 찾을 수 없습니다.");
     }
   }, []);
 
   return <h1>로그인 처리 중입니다...</h1>;
-
+}

--- a/src/components/common/AuthCard.tsx
+++ b/src/components/common/AuthCard.tsx
@@ -4,8 +4,8 @@ interface AuthCardProps {
 
 const AuthCard = ({ children }: AuthCardProps) => {
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <div className="card w-80 h-[400px] bg-base-100 border border-base-300 shadow-sm p-6">
+    <main className="flex min-h-screen items-center justify-center px-4">
+      <div className="card w-full max-w-md bg-base-100 border border-base-300 shadow-sm p-6">
         <div className="card-body items-center justify-center p-0">
           {children}
         </div>

--- a/src/components/common/MobileDrawerMenu.tsx
+++ b/src/components/common/MobileDrawerMenu.tsx
@@ -4,7 +4,7 @@ import { useAuthStore } from "@/store/authStore";
 import Link from "next/link";
 import { Bell } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { clearAuthStorage } from "@/lib/logout"
+import { clearAuthStorage } from "@/lib/logout";
 
 const MobileDrawerMenu = () => {
   const { user, logout } = useAuthStore();
@@ -12,7 +12,7 @@ const MobileDrawerMenu = () => {
 
   const handleLogout = () => {
     logout();
-    clearAuthStorage()
+    clearAuthStorage();
     window.location.href = "/";
   };
 
@@ -32,14 +32,13 @@ const MobileDrawerMenu = () => {
               className="flex items-center gap-1 hover:underline"
             >
               <span className="font-semibold">{user.name}님</span>
-              <span className="text-sm text-amber-700">{user.current_point}P</span>
+              <span className="text-sm text-amber-700">{user.currentPoint}P</span>
             </button>
             <button className="btn btn-ghost btn-circle">
               <Bell className="w-5 h-5" />
             </button>
           </div>
 
-          {/* 로그인 상태일 때 */}
           <button
             onClick={() => handleLinkClick("/coffee-chat")}
             className="btn btn-outline btn-sm w-full"
@@ -47,7 +46,6 @@ const MobileDrawerMenu = () => {
             커피챗 바로가기
           </button>
 
-          {/* 로그아웃 */}
           <button onClick={handleLogout} className="btn btn-sm w-full">
             로그아웃
           </button>

--- a/src/components/feature/auth/SocialLogin.tsx
+++ b/src/components/feature/auth/SocialLogin.tsx
@@ -6,35 +6,34 @@ import { toast } from "react-toastify";
 import { END_POINT } from "@/constants/endPoint";
 
 const SocialLogin = () => {
-
   const handleNaverLogin = () => {
     try {
       window.location.href = END_POINT.NAVER_REDIRECT;
-    } catch (error) {
-      console.error("소셜 로그인 오류:", error);
+    } catch {
       toast.error("로그인 실패. 관리자에게 문의하세요.");
     }
   };
 
   return (
     <AuthCard>
-      <div className="flex flex-col items-center justify-center w-full h-full gap-3">
+      <div className="flex flex-col items-center justify-center w-full gap-6 px-4 py-10">
         <Image
           src="/logo.PNG"
-          alt="BootTalk Logo"
+          alt="BootTalk 로고"
           width={300}
           height={90}
-          className="object-contain mt-6 mb-10"
+          className="object-contain mb-3"
         />
-        <p className="text-base text-center leading-relaxed">
-          우리 부트톡
+        <p className="text-center text-base leading-relaxed text-gray-600">
+          부트톡,
           <br />
-          너희들의 미래를 담당하지
+          <span className="text-gray-500 font-normal">
+            부트캠퍼들의 내일을 연결하다
+          </span>
         </p>
         <button
           onClick={handleNaverLogin}
-          style={{ backgroundColor: "#03C75A" }}
-          className="btn text-white text-base min-w-[180px] min-h-[44px] mb-10 rounded-lg"
+          className="btn text-white text-base font-medium w-full max-w-[240px] h-[48px] rounded-lg shadow-md bg-[#03C75A] hover:bg-[#026B3A] transition-colors duration-200 ease-in-out"
         >
           네이버로 로그인
         </button>

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -32,4 +32,5 @@ export const END_POINT = {
   DELETE_REVIEW: (reviewId: number) => `/api/reviews/my/${reviewId}`,
   SSE_CONNECT: "/api/sse-connect",
   MARK_ALL_AS_READ: (time: string) => `/api/notifications?time=${time}`,
+  MY_POINTS: "/api/points/me"
 } as const;

--- a/src/hooks/useGetPointOnLogin.ts
+++ b/src/hooks/useGetPointOnLogin.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { axiosDefault } from "@/api/axiosInstance";
+import { END_POINT } from "@/constants/endPoint";
+import { useEffect } from "react";
+import { useUserStore } from "@/store/user";
+
+export const useGetPointsOnLogin = () => {
+  const { user, setUser } = useUserStore();
+
+  const { data, error, refetch } = useQuery({
+    queryKey: ["myPoints"],
+    queryFn: async () => {
+      const res = await axiosDefault.get(END_POINT.MY_POINTS);
+      return res.data;
+    },
+    enabled: false,
+  });
+
+  useEffect(() => {
+    if (data !== undefined && user) {
+      setUser({
+        ...user,
+        currentPoint: data,
+      });
+    }
+  }, [data, user, setUser]);
+
+  return { data, error, refetch };
+};

--- a/src/mocks/db/db.ts
+++ b/src/mocks/db/db.ts
@@ -576,7 +576,7 @@ export const DB = {
     {
       point_id: 1,
       user_id: 1,
-      current_points: 2,
+      currentPoint: 2,
       changed_points: 2,
       type: "EARN",
       event_type: "회원가입",
@@ -585,7 +585,7 @@ export const DB = {
     {
       point_id: 2,
       user_id: 1,
-      current_points: 3,
+      currentPoint: 3,
       changed_points: 1,
       type: "EARN",
       event_type: "리뷰작성",
@@ -594,7 +594,7 @@ export const DB = {
     {
       point_id: 3,
       user_id: 1,
-      current_points: 2,
+      currentPoint: 2,
       changed_points: -1,
       type: "USE",
       event_type: "커피챗",

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,11 +1,11 @@
 import { create } from "zustand";
-import type { AuthUser, UserStoreUser } from "@/types/user";
+import type { AuthUser, UserInfo } from "@/types/response";
 
-export const transformToAuthUser = (user: UserStoreUser): AuthUser => ({
-  id: user.t_user_id,
+export const transformToAuthUser = (user: UserInfo): AuthUser => ({
   name: user.name,
   email: user.email,
-  current_point: user.current_point,
+  currentPoint: user.currentPoint,
+  profileImage: user.profileImage,
 });
 
 interface AuthState {

--- a/src/store/user.ts
+++ b/src/store/user.ts
@@ -1,10 +1,10 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import type { UserStoreUser } from "@/types/user";
+import type { UserInfo } from "@/types/response";
 
 interface UserStore {
-  user: UserStoreUser | null;
-  setUser: (user: UserStoreUser) => void;
+  user: UserInfo | null;
+  setUser: (user: UserInfo) => void;
   logout: () => void;
 }
 

--- a/src/types/response.ts
+++ b/src/types/response.ts
@@ -76,3 +76,10 @@ export interface ReviewBootcamp {
   categoryName: string;
   trainingProgramId: string;
 }
+
+export interface AuthUser {
+  name: string;
+  email: string;
+  profileImage: string | null;
+  currentPoint: number;
+}


### PR DESCRIPTION
## 변경사항 설명
<!-- 어떤 변경사항이 있었는지 간략히 설명해주세요 -->
1. 네이버 소셜 로그인 연동 (토큰 저장 및 사용자 정보 요청 포함)
2. 로그인 후 Header에 사용자 포인트 반영 기능 추가
3. 로그인 시 마이페이지 진입 및 로그아웃 처리 흐름 정리
4. 불필요한 mockUser 코드 및 console.log 제거
5. 로그인 후 직무 목록 등 인증 필요 없는 공개 API도 문제없이 호출되도록 axios 설정 개선


## 리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이 있다면 알려주세요 -->
1. 로그인 성공 후 토큰이 localStorage에 정상 저장되고, 사용자 정보가 상태로 잘 전달되는지 확인
2. 로그인 시 Header 우측에 포인트가 잘 반영되고, 로그아웃 시 상태 초기화가 잘 되는지 확인
3. 소셜 로그인 이후 리다이렉트 흐름이 `/login/callback` → `/social-register` → `/` 으로 자연스럽게 작동하는지
4. 배포 환경에서 콘솔, 토스트 메시지 등 불필요한 디버깅 요소가 없는지

## 테스트 방법
<!-- 이 변경사항을 테스트하는 방법을 설명해주세요 -->
1. 로컬 환경에서 네이버 소셜 로그인 버튼 클릭
2. 로그인 성공 후 `/social-register`에서 직무 선택 후 저장
3. 메인 페이지 이동 시 Header 우측에 사용자 이름 및 포인트 노출 확인
4. 로그아웃 시 상태 초기화 및 메인으로 리다이렉트 되는지 확인
