### PR TITLE
♻️ 커피챗 페이지 리팩토링

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 
 const getBaseURL = () => {
   const isDev = process.env.NODE_ENV === "development";
-  const useMock = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+  const useMock = process.env.NEXT_PUBLIC_USE_MOCK === "false";
 
   if (isDev && useMock) return process.env.NEXT_PUBLIC_API_MOCKING;
   return process.env.NEXT_PUBLIC_API_URL;
@@ -40,4 +40,3 @@ axiosDefault.interceptors.response.use(
     return Promise.reject(error);
   }
 );
-

--- a/src/components/feature/coffee-chat/mentor/ChatRequestModal.tsx
+++ b/src/components/feature/coffee-chat/mentor/ChatRequestModal.tsx
@@ -93,7 +93,11 @@ const ChatRequestModal: React.FC<ChatRequestModalProps> = ({
       },
       onError: (error) => {
         console.error("커피챗 신청 오류:", error);
-        toast.error("커피챗 신청 중 오류가 발생했습니다.");
+        if (error.message.includes("409")) {
+          toast.warning("이미 신청한 커피챗입니다.");
+        } else {
+          toast.error("커피챗 신청 중 오류가 발생했습니다.");
+        }
       },
     });
   };

--- a/src/components/feature/coffee-chat/my-chat/CoffeeChatActionModal.tsx
+++ b/src/components/feature/coffee-chat/my-chat/CoffeeChatActionModal.tsx
@@ -3,6 +3,7 @@ import Modal from "@/components/common/modal/CommonModal";
 import React from "react";
 
 export type ActionType = "APPROVE" | "REJECT" | "CANCEL";
+export type UserRole = "MENTOR" | "MENTEE";
 
 interface CoffeeChatActionModalProps {
   isOpen: boolean;
@@ -11,7 +12,7 @@ interface CoffeeChatActionModalProps {
   onClose: () => void;
   onConfirm: () => void;
   isLoading?: boolean;
-  isMentor: boolean;
+  userRole: UserRole;
 }
 
 const CoffeeChatActionModal: React.FC<CoffeeChatActionModalProps> = ({
@@ -21,7 +22,7 @@ const CoffeeChatActionModal: React.FC<CoffeeChatActionModalProps> = ({
   onClose,
   onConfirm,
   isLoading = false,
-  isMentor = true,
+  userRole = "MENTOR",
 }) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} hideHeader={true} size="sm">
@@ -42,7 +43,7 @@ const CoffeeChatActionModal: React.FC<CoffeeChatActionModalProps> = ({
         {actionType === "CANCEL" && isPenalty && (
           <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
             <p className="font-bold">주의!</p>
-            {isMentor ? (
+            {userRole === "MENTOR" ? (
               <p>
                 커피챗 시작 1일 전 이후 취소 시, 멘토 활동이 1개월간 제한됩니다.
               </p>
@@ -59,11 +60,11 @@ const CoffeeChatActionModal: React.FC<CoffeeChatActionModalProps> = ({
             className="btn btn-outline"
             disabled={isLoading}
           >
-            취소
+            돌아가기
           </button>
           <button
             onClick={onConfirm}
-            className={`btn btn-outline${
+            className={`btn btn-outline ${
               actionType === "APPROVE"
                 ? "btn-success"
                 : actionType === "REJECT"

--- a/src/components/feature/coffee-chat/my-chat/ReceivedListTab.tsx
+++ b/src/components/feature/coffee-chat/my-chat/ReceivedListTab.tsx
@@ -39,7 +39,7 @@ const ReceivedListTab = () => {
     modalState,
     closeModal,
     confirmAction,
-  } = useCoffeeChatActions();
+  } = useCoffeeChatActions("MENTOR");
 
   const handleCoffeeChatClick = (coffeechat: CoffeeChat) => {
     setSelectedCoffeeChat(coffeechat);
@@ -167,7 +167,7 @@ const ReceivedListTab = () => {
         onClose={closeModal}
         onConfirm={confirmAction}
         isLoading={isApproving || isRejecting || isCanceling}
-        isMentor={true}
+        userRole="MENTOR"
       />
     </div>
   );

--- a/src/components/feature/coffee-chat/my-chat/SentListTab.tsx
+++ b/src/components/feature/coffee-chat/my-chat/SentListTab.tsx
@@ -30,7 +30,7 @@ const SentListTab = () => {
   });
 
   const { handleCancel, isCanceling, modalState, closeModal, confirmAction } =
-    useCoffeeChatActions();
+    useCoffeeChatActions("MENTEE");
 
   const handleCoffeeChatClick = (coffeechat: CoffeeChat) => {
     setSelectedCoffeeChat(coffeechat);
@@ -136,7 +136,7 @@ const SentListTab = () => {
         onClose={closeModal}
         onConfirm={confirmAction}
         isLoading={isCanceling}
-        isMentor={false}
+        userRole="MENTEE"
       />
     </div>
   );

--- a/src/components/feature/coffee-chat/my-chat/getStatusBadge.tsx
+++ b/src/components/feature/coffee-chat/my-chat/getStatusBadge.tsx
@@ -40,7 +40,7 @@ export const getStatusBadge = (status: string) => {
 
   return (
     <div
-      className={`px-2 py-0.5 text-xs font-medium rounded border ${bgColor} ${textColor} ${borderColor}`}
+      className={`px-2 py-0.5 text-xs font-medium rounded border whitespace-nowrap ${bgColor} ${textColor} ${borderColor}`}
     >
       {text}
     </div>

--- a/src/constants/endPoint.ts
+++ b/src/constants/endPoint.ts
@@ -14,6 +14,8 @@ export const END_POINT = {
   FILE_UPLOAD: "/api/file/upload",
   SENT_COFFEE_CHATS: "/api/coffee-chats/applications",
   RECEIVED_COFFEE_CHATS: "/api/coffee-chats/applications/received",
+  RECEIVED_CANCEL: (coffeeChatAppId: string) =>
+    `/api/coffee-chats/applications/${coffeeChatAppId}`,
   STATUS_CHATS: (coffeeChatAppId: string) =>
     `/api/coffee-chats/applications/received/${coffeeChatAppId}/status`,
   BOOTCAMP_DETAIL: (id: string) => `/api/bootcamps/${id}`,
@@ -24,6 +26,7 @@ export const END_POINT = {
   NOTIFICATIONS: "/api/notifications",
   CHAT_ROOM: (roomUuid: string) => `/chat-rooms/${roomUuid}`,
   CHAT_ROOM_LIST: "/api/chat-rooms",
+  CHAT_MESSAGE: (roomUuid: string) => `/api/chat-rooms/${roomUuid}/messages`,
   ADMIN_CERTIFICATION: "/api/admin/certifications",
   BOOTCAMPS_AUTOCOMPLETE: "/api/bootcamps/autocomplete",
   NAVER_REDIRECT: "/api/oauth2/authorization",

--- a/src/hooks/chat/useGetMessages.ts
+++ b/src/hooks/chat/useGetMessages.ts
@@ -1,11 +1,9 @@
 import { axiosDefault } from "@/api/axiosInstance";
+import { END_POINT } from "@/constants/endPoint";
 import { useQuery } from "@tanstack/react-query";
 
 const fetchPreviousMessages = async (roomUuid: string) => {
-  const response = await axiosDefault.get(
-    `/api/chat-rooms/${roomUuid}/messages`,
-    {}
-  );
+  const response = await axiosDefault.get(END_POINT.CHAT_MESSAGE(roomUuid), {});
   return response.data;
 };
 

--- a/src/hooks/coffee-chat/useMentorApplication.ts
+++ b/src/hooks/coffee-chat/useMentorApplication.ts
@@ -21,7 +21,12 @@ const submitChatRequest = async (requestData: MentorApplicationData) => {
 
 export const useMentorApplication = (coffeeChatInfoId: string) => {
   const { data: mentorApplicationTime, isLoading } = useQuery({
-    queryKey: ["mentorApplicationTime", coffeeChatInfoId],
+    queryKey: [
+      "mentorApplicationTime",
+      "sentList",
+      "receivedList",
+      coffeeChatInfoId,
+    ],
     queryFn: () => fetchMentorApplicationTime(coffeeChatInfoId),
     enabled: !!coffeeChatInfoId,
   });

--- a/src/hooks/coffee-chat/useMentorRegistration.ts
+++ b/src/hooks/coffee-chat/useMentorRegistration.ts
@@ -50,7 +50,7 @@ export const useMentorRegistration = (options = { enabled: true }) => {
 
   // 멘토 정보 조회 쿼리
   const mentorDataQuery = useQuery({
-    queryKey: ["mentorData"],
+    queryKey: ["mentorData", "mentorList"],
     queryFn: fetchMentorData,
     enabled: options.enabled, // 조건부 실행을 위한 옵션
     retry: false,
@@ -60,7 +60,7 @@ export const useMentorRegistration = (options = { enabled: true }) => {
   const createMentorMutation = useMutation({
     mutationFn: createMentorInfo,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mentorData"] });
+      queryClient.invalidateQueries({ queryKey: ["mentorData", "mentorList"] });
     },
     onError: (error) => {
       console.error("멘토 정보 등록 오류:", error);
@@ -71,7 +71,7 @@ export const useMentorRegistration = (options = { enabled: true }) => {
   const updateMentorMutation = useMutation({
     mutationFn: updateMentorInfo,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mentorData"] });
+      queryClient.invalidateQueries({ queryKey: ["mentorData", "mentorList"] });
     },
     onError: (error) => {
       console.error("멘토 정보 수정 오류:", error);
@@ -82,7 +82,7 @@ export const useMentorRegistration = (options = { enabled: true }) => {
   const deleteMentorMutation = useMutation({
     mutationFn: deleteMentorInfo,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["mentorData"] });
+      queryClient.invalidateQueries({ queryKey: ["mentorData", "mentorList"] });
     },
     onError: (error) => {
       console.error("멘토 등록 삭제 오류:", error);


### PR DESCRIPTION
## 변경사항 설명
<!-- 어떤 변경사항이 있었는지 간략히 설명해주세요 -->
- 커피챗 중복 신청 시 409 Conflict 에러에 대한 예외 처리 로직 추가
- 멘토/멘티 역할 구분 로직을 반영하여 각 롤에 맞는 훅 분기 호출
- 일부 상수 분리처리가 안된 endpoint를 분리하여 관리 효율성 및 가독성 향상
- React Query의 쿼리 키를 명시적으로 추가하고, 관련 데이터 변경 시 자동 업데이트 처리
## 관련 이슈
<!-- 이 PR이 해결하는 이슈 번호를 작성해주세요 (예: #123) -->

## 리뷰 포인트
<!-- 리뷰어가 특히 집중해서 봐야 할 부분이 있다면 알려주세요 -->
- 409 에러 처리 분기 로직이 예외 없이 동작하는지
- 멘토/멘티 분기에 따라 올바른 훅 및 endpoint가 호출되고 있는지
- 쿼리 키 변경 후 자동으로 목록 업데이트가 정상 작동하는지
## 테스트 방법
<!-- 이 변경사항을 테스트하는 방법을 설명해주세요 -->
1. 멘티와 멘토 계정으로 각각 커피챗 신청 시도를 해보기
2. 이미 신청한 상태에서 중복 신청 시도하여 409 에러가 정상적으로 처리되는지 확인
3. 커피챗 목록에서 신청/취소 등 변경 사항이 반영되는지 실시간 확인
4. 네트워크 탭을 통해 역할에 따른 endpoint 분리가 실제 적용되는지 확인
## 스크린샷 (UI 변경이 있는 경우)
<!-- UI 변경이 있는 경우 스크린샷을 첨부해주세요 -->
- UI 변경 없음
## 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 모든 테스트가 통과합니다
- [x] 관련 문서를 업데이트했습니다
